### PR TITLE
Make DefaultRxRestClient log like DefaultRestClientRequest

### DIFF
--- a/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientRequest.java
+++ b/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientRequest.java
@@ -112,7 +112,7 @@ public class DefaultRestClientRequest<T> implements RestClientRequest<T> {
                 httpClientResponse.exceptionHandler(null);
                 if (log.isWarnEnabled()) {
                     final String body = new String(buffer.getBytes(), Charsets.UTF_8);
-                    log.warn("Http request to {} FAILED. Return status: {}, message: {}, body: {}", new Object[]{uri,httpClientResponse.statusCode(), httpClientResponse.statusMessage(), body});
+                    log.error("Http request to {} FAILED. Return status: {}, message: {}, body: {}", new Object[]{uri,httpClientResponse.statusCode(), httpClientResponse.statusMessage(), body});
                 }
 
                 RuntimeException exception = null;


### PR DESCRIPTION
In case we have really hard exceptions like

java.nio.channels.UnresolvedAddressException
	at sun.nio.ch.Net.checkAddress(Net.java:101)

which do not really give any information about the nature of the unresolved
host we need the information that is currently only available at the level of
the DefaultRxRestClient. So we at least log it (DefaultRestClientRequest does
so as well) that we know what was unresolvable.