### PR TITLE
[NOREF] Fixing package visibility

### DIFF
--- a/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientRequest.java
+++ b/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientRequest.java
@@ -88,18 +88,18 @@ public class DefaultRestClientRequest<T> implements RestClientRequest<T> {
     private boolean globalHeadersPopulated = false;
     private MultiKey cacheKey;
 
-    public DefaultRestClientRequest(Vertx vertx,
-                                    DefaultRestClient restClient,
-                                    HttpClient httpClient,
-                                    List<HttpMessageConverter> httpMessageConverters,
-                                    HttpMethod method,
-                                    String uri,
-                                    Class<T> responseClass,
-                                    Handler<RestClientResponse<T>> responseHandler,
-                                    Long timeoutInMillis,
-                                    RequestCacheOptions requestCacheOptions,
-                                    MultiMap globalHeaders,
-                                    @Nullable Handler<Throwable> exceptionHandler) {
+    DefaultRestClientRequest(Vertx vertx,
+                             DefaultRestClient restClient,
+                             HttpClient httpClient,
+                             List<HttpMessageConverter> httpMessageConverters,
+                             HttpMethod method,
+                             String uri,
+                             Class<T> responseClass,
+                             Handler<RestClientResponse<T>> responseHandler,
+                             Long timeoutInMillis,
+                             RequestCacheOptions requestCacheOptions,
+                             MultiMap globalHeaders,
+                             @Nullable Handler<Throwable> exceptionHandler) {
         checkNotNull(vertx, "vertx must not be null");
         checkNotNull(restClient, "restClient must not be null");
         checkNotNull(httpClient, "httpClient must not be null");

--- a/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientResponse.java
+++ b/src/main/java/com/hubrick/vertx/rest/impl/DefaultRestClientResponse.java
@@ -46,11 +46,11 @@ public class DefaultRestClientResponse<T> implements RestClientResponse<T> {
     private final StreamBase streamBase;
     private Handler<Throwable> exceptionHandler;
 
-    public DefaultRestClientResponse(List<HttpMessageConverter> httpMessageConverters,
-                                     Class<T> clazz,
-                                     HttpInputMessage httpInputMessage,
-                                     StreamBase streamBase,
-                                     @Nullable Handler<Throwable> exceptionHandler) {
+    DefaultRestClientResponse(List<HttpMessageConverter> httpMessageConverters,
+                              Class<T> clazz,
+                              HttpInputMessage httpInputMessage,
+                              StreamBase streamBase,
+                              @Nullable Handler<Throwable> exceptionHandler) {
         checkNotNull(httpMessageConverters, "dataMappers must not be null");
         checkArgument(!httpMessageConverters.isEmpty(), "dataMappers must not be empty");
         checkNotNull(clazz, "clazz must not be null");


### PR DESCRIPTION
The only dependency outside the package was in the `HttpStatusCodeException` in a method called `getResponseBody` which doesn't return the body as you requested, or at least implied in the method name, but a RestClientResponse, which doesn't contain only the body but pretty much all the information you have already in the `HttpStatusCodeException` as well, so this leads to a redundant syntax: `exception.getResponseBody(AnyDto.class).getBody()`, creating a dependency with the `impl` package that doesn't need to be there. Also, the documentation was wrong. 